### PR TITLE
Display regex correctly on use-tailwindcss example

### DIFF
--- a/src/pages/examples/use-tailwind-css.svx
+++ b/src/pages/examples/use-tailwind-css.svx
@@ -34,7 +34,7 @@ const purgecss = require('@fullhuman/postcss-purgecss')({
   
     whitelistPatterns: [/svelte-/],
   
-    defaultExtractor: content => content.match(/[\w-/:]+(?<!:)/g) || []
+    defaultExtractor: content => content.match(/[\\w-/:]+(?<!:)/g) || []
   });
   
 const production = !process.env.ROLLUP_WATCH


### PR DESCRIPTION
The regex on the webpage is not the same as the raw file.

So, I have to add another **\\** char to make sure the regex displayed on the website is correct.

This fixes the **invalid regular expression** issue when running the build script.