### PR TITLE
style: add css animation to accordion caret

### DIFF
--- a/src/components/Accordion.svelte
+++ b/src/components/Accordion.svelte
@@ -10,13 +10,25 @@
 
 <button class="c-navigation-mobile__section-header" on:click="{handleClick}">
     <span>{title}</span>
-    {#if navOpen}
-        <Icon name="chevron-up" />
-    {:else}
+    <div data-nav-open={navOpen}>
         <Icon name="chevron-down" />
-    {/if}
+    </div>
 </button>
 
 {#if navOpen}
 <slot></slot>
 {/if}
+
+<style>
+    :global(div[data-nav-open] svg) {
+        display: block;
+        transition: transform 100ms ease;
+    }
+    :global(div[data-nav-open="false"] svg) {
+        transform: rotate3d(0, 0, 0, 0deg);
+    }
+
+    :global(div[data-nav-open="true"] svg) {
+        transform: rotate3d(0, 0, -1, -180deg);
+    }
+</style>


### PR DESCRIPTION
ref #181 

- Adds animated caret on mobile nav accordion
- Removes if/else statement and usage of `chevron-up` in favor of CSS animations using custom attributes and container style selection
- sets SVG's `display: block` to remove unwanted whitespace appearing below the icon (this was causing a bloated focus outline)