### PR TITLE
Correct the example for config | runtime.svelte

### DIFF
--- a/src/pages/docs/config/runtime.svelte
+++ b/src/pages/docs/config/runtime.svelte
@@ -59,7 +59,7 @@
           parse: search => fromEntries(new URLSearchParams(search)),
           stringify: params => '?' + (new URLSearchParams(params)).toString()
         },
-        urlTransform = {
+        urlTransform: {
           apply: url => \`/my-base\${url}\`, //external URL
           remove: url => url.replace('/my-base', ''), //internal URL
         },


### PR DESCRIPTION
Syntax for config object was incorrect on line 62; equal sign should be colon.